### PR TITLE
Fix fractional days error in time handling

### DIFF
--- a/R/ncTime.R
+++ b/R/ncTime.R
@@ -23,8 +23,8 @@ numericToTime <- function(values, unitText) {
     seconds = origin + lubridate::seconds(values),
     minutes = origin + lubridate::minutes(values),
     hours = origin + lubridate::hours(values),
-    days = origin + lubridate::days(values),
-    weeks = origin + lubridate::weeks(values),
+    days = origin + lubridate::hours(values * 24),  # Convert fractional days to hours
+    weeks = origin + lubridate::hours(values * 24 * 7),  # Convert fractional weeks to hours
     years = origin + lubridate::years(values),
     stop("Unknown time unit: ", match[2])
   )
@@ -64,7 +64,7 @@ ncLoadTimeDimension <- function(nc, timeDimName = NULL) {
     if (str_detect(timeUnitDescription, patternDaysSince)) {
       startDayText <- str_match(timeUnitDescription, patternDaysSince)[,2]
       startDate <- as.Date(startDayText)
-      timeDates <- startDate + lubridate::days(timeValues)
+      timeDates <- startDate + lubridate::hours(timeValues * 24)  # Convert fractional days to hours
       years <- lubridate::year(timeDates)
       formattedStartDate <- format(startDate, "%B %d, %Y")
       cat("Assume that time values are days since year", startDate, "(", formattedStartDate, ").\n")


### PR DESCRIPTION
This PR fixes the "periods must have integer values" error that occurs when loading NetCDF files with fractional time values.

## Problem
- NetCDF files with time units like "days since 1661-01-01" often contain fractional day values (e.g., 69030.5 for mid-year timestamps)
- `lubridate::days()` and `lubridate::weeks()` expect integer values, causing the error: "invalid class 'Period' object: periods must have integer values"

## Solution
- Convert fractional days to hours using `lubridate::hours(values * 24)` instead of `lubridate::days(values)`
- Convert fractional weeks to hours using `lubridate::hours(values * 24 * 7)` instead of `lubridate::weeks(values)`
- This preserves precision while avoiding the integer requirement

## Files Changed
- `R/ncTime.R`: Fixed both `numericToTime()` and `ncLoadTimeDimension()` functions